### PR TITLE
Simplify and shorten code

### DIFF
--- a/eod_historical_data/data.py
+++ b/eod_historical_data/data.py
@@ -19,6 +19,9 @@ EOD_HISTORICAL_DATA_API_URL: str = config_data.EOD_HISTORICAL_DATA_API_URL
 def set_envar() -> str:
     return EOD_HISTORICAL_DATA_API_KEY_ENV_VAR
 
+def inv_api_key():
+    print(f"API Key Restricted, Try upgrading your API Key: {__name__}")
+    return sentinel
 
 @_handle_environ_error
 @_handle_request_errors
@@ -28,10 +31,10 @@ def get_eod_data(symbol: str, exchange: str, start: typing.Union[str, int] = Non
     """
         Returns EOD (end of day data) for a given symbol
     """
-    symbol_exchange: str = "{}.{}".format(symbol, exchange)
+    symbol_exchange: str = f"{symbol}.{exchange}"
     session: requests.Session = _init_session(session)
     start, end = _sanitize_dates(start, end)
-    endpoint: str = "/eod/{}".format(symbol_exchange)
+    endpoint: str = f"/eod/{symbol_exchange}"
     url: str = EOD_HISTORICAL_DATA_API_URL + endpoint
     params: dict = {
         "api_token": api_key,
@@ -39,7 +42,7 @@ def get_eod_data(symbol: str, exchange: str, start: typing.Union[str, int] = Non
         "to": _format_date(end)
     }
     r: requests.Response = session.get(url, params=params)
-    print('status code : {}'.format(r.status_code))
+    print(f'status code : {r.status_code}')
 
     if r.status_code == requests.codes.ok:
         # NOTE engine='c' which is default does not support skip footer
@@ -47,8 +50,7 @@ def get_eod_data(symbol: str, exchange: str, start: typing.Union[str, int] = Non
                                                            skipfooter=1, parse_dates=[0], index_col=0)
         return df
     elif r.status_code == api_key_not_authorized:
-        print("API Key Restricted, Try upgrading your API Key: {}".format(__name__))
-        return sentinel
+        inv_api_key()
     else:
         params["api_token"] = "YOUR_HIDDEN_API"
         raise RemoteDataError(r.status_code, r.reason, _url(url, params))
@@ -58,9 +60,9 @@ def get_eod_data(symbol: str, exchange: str, start: typing.Union[str, int] = Non
 async def get_eod_data_async(symbol: str, exchange: str, start: typing.Union[str, int] = None,
                              end: typing.Union[str, int] = None,
                              api_key: str = EOD_HISTORICAL_DATA_API_KEY_DEFAULT) -> typing.Union[pd.DataFrame, None]:
-    symbol_exchange: str = "{}.{}".format(symbol, exchange)
+    symbol_exchange: str = f"{symbol}.{exchange}"
     start, end = _sanitize_dates(start, end)
-    endpoint: str = "/eod/{}".format(symbol_exchange)
+    endpoint: str = f"/eod/{symbol_exchange}"
     url: str = EOD_HISTORICAL_DATA_API_URL + endpoint
     params: dict = {
         "api_token": api_key,
@@ -75,8 +77,7 @@ async def get_eod_data_async(symbol: str, exchange: str, start: typing.Union[str
                                                                    skipfooter=1, parse_dates=[0], index_col=0)
                 return df
             elif response.status == api_key_not_authorized:
-                print("API Key Restricted, Try upgrading your API Key: {}".format(__name__))
-                return sentinel
+                inv_api_key()
             else:
                 params["api_token"] = "YOUR_HIDDEN_API"
                 raise RemoteDataError(response.status, response.reason, _url(url, params))
@@ -90,10 +91,10 @@ def get_dividends(symbol: str, exchange: str, start: typing.Union[str, int] = No
     """
         Returns dividends
     """
-    symbol_exchange: str = "{},{}".format(symbol, exchange)
+    symbol_exchange: str = f"{symbol},{exchange}"
     session: requests.Session = _init_session(session)
     start, end = _sanitize_dates(start, end)
-    endpoint: str = "/div/{}".format(symbol_exchange)
+    endpoint: str = f"/div/{symbol_exchange}"
     url: str = EOD_HISTORICAL_DATA_API_URL + endpoint
     params: dict = {
         "api_token": api_key,
@@ -101,7 +102,7 @@ def get_dividends(symbol: str, exchange: str, start: typing.Union[str, int] = No
         "to": _format_date(end)
     }
     r: requests.Response = session.get(url, params=params)
-    print('status code : {}'.format(r.status_code))
+    print(f'status code : {r.status_code}')
 
     if r.status_code == requests.codes.ok:
         # NOTE engine='c' which is default does not support skip footer
@@ -111,8 +112,7 @@ def get_dividends(symbol: str, exchange: str, start: typing.Union[str, int] = No
         ts = df["Dividends"]
         return ts
     elif r.status_code == api_key_not_authorized:
-        print("API Key Restricted, Try upgrading your API Key: {}".format(__name__))
-        return sentinel
+        inv_api_key()
     else:
         params["api_token"] = "YOUR_HIDDEN_API"
         raise RemoteDataError(r.status_code, r.reason, _url(url, params))
@@ -126,9 +126,9 @@ async def get_dividends_async(symbol: str, exchange: str, start: typing.Union[st
     """
         Returns dividends
     """
-    symbol_exchange: str = "{},{}".format(symbol, exchange)
+    symbol_exchange: str = f"{symbol},{exchange}"
     start, end = _sanitize_dates(start, end)
-    endpoint: str = "/div/{}".format(symbol_exchange)
+    endpoint: str = f"/div/{symbol_exchange}"
     url: str = EOD_HISTORICAL_DATA_API_URL + endpoint
     params: dict = {
         "api_token": api_key,
@@ -146,8 +146,7 @@ async def get_dividends_async(symbol: str, exchange: str, start: typing.Union[st
                 ts = df["Dividends"]
                 return ts
             elif response.status == api_key_not_authorized:
-                print("API Key Restricted, Try upgrading your API Key: {}".format(__name__))
-                return sentinel
+                inv_api_key()
             else:
                 params["api_token"] = "YOUR_HIDDEN_API"
                 raise RemoteDataError(response.status, response.reason, _url(url, params))
@@ -161,19 +160,18 @@ def get_exchange_symbols(exchange_code: str,
         Returns list of symbols for a given exchange
     """
     session: requests.Session = _init_session(session)
-    endpoint: str = "/exchanges/{exchange_code}".format(exchange_code=exchange_code)
+    endpoint: str = f"/exchanges/{exchange_code}"
     url: str = EOD_HISTORICAL_DATA_API_URL + endpoint
     params: dict = {
         "api_token": api_key
     }
     r: requests.Response = session.get(url, params=params)
-    print('status code : {}'.format(r.status_code))
+    print(f'status code : {r.status_code}')
     if r.status_code == requests.codes.ok:
         df: typing.Union[None, pd.DataFrame] = pd.read_csv(StringIO(r.text), engine='python', skipfooter=1, index_col=0)
         return df
     elif r.status_code == api_key_not_authorized:
-        print("API Key Restricted, Try upgrading your API Key: {}".format(__name__))
-        return sentinel
+        inv_api_key()
     else:
         params["api_token"] = "YOUR_HIDDEN_API"
         raise RemoteDataError(r.status_code, r.reason, _url(url, params))
@@ -187,7 +185,7 @@ async def get_exchange_symbols_async(exchange_code: str,
     """
         Returns list of symbols for a given exchange
     """
-    endpoint: str = "/exchanges/{exchange_code}".format(exchange_code=exchange_code)
+    endpoint: str = f"/exchanges/{exchange_code}"
     url: str = EOD_HISTORICAL_DATA_API_URL + endpoint
     params: dict = {
         "api_token": api_key
@@ -200,8 +198,7 @@ async def get_exchange_symbols_async(exchange_code: str,
                                                                    skipfooter=1, index_col=0)
                 return df
             elif response.status == api_key_not_authorized:
-                print("API Key Restricted, Try upgrading your API Key: {}".format(__name__))
-                return sentinel
+                inv_api_key()
             else:
                 params["api_token"] = "YOUR_HIDDEN_API"
                 raise RemoteDataError(response.status, response.reason, _url(url, params))


### PR DESCRIPTION
I shortened the formatted strings by putting f's at the beginning of them rather than .format at the end. I also defined a function for the Restricted API Key sections in order to further shorten the code.